### PR TITLE
add missing stylesheets

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -12,10 +12,14 @@
 
         <!-- stylesheets -->
         <link href="{{ url_for('static', filename='css/flag-icon-css/css/flag-icon.min.css') }}" rel="stylesheet">
-        <link href="{{ url_for('static', filename='css/font-awesome/css/font-awesome.min.css') }}" rel="stylesheet">
-        <link href="{{ url_for('static', filename='css/simple-line-icons/css/simple-line-icons.css') }}" rel="stylesheet">
+        <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/simple-line-icons/2.4.1/css/simple-line-icons.css" integrity="sha256-q5+FXlQok94jx7fkiX65EGbJ27/qobH6c6gmhngztLE=" crossorigin="anonymous" />
+
         <link href="{{ url_for('static', filename='bootstrap/css/bootstrap.css') }}" rel="stylesheet">
         <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+
+
+        <link href="{{ url_for('static', filename='/coreui/dist/css/coreui.css') }}" rel="stylesheet">
 
         <!-- javascript -->
         <!--


### PR DESCRIPTION
the login page loads without styling due to missing links and static files.
- adds links to get font-awesome and simle-line-icons.
- adds link to a missing local coreui css file.