### PR TITLE
Fix API key deletion bug

### DIFF
--- a/app/templates/dark_layout.html
+++ b/app/templates/dark_layout.html
@@ -64,22 +64,26 @@
                       </li>
                       {% endif %}
 
-                      {% if current_user.has_role('admin') or current_user.has_role('dev') %}
-                      <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('apikeys.apikeys_index') }}">
-                          <i class="nav-icon icon-drop"></i> API Keys</a>
-                      </li>
+	              {% if current_user.is_authenticated %}
+			{% if current_user.has_role('admin') or current_user.has_role('dev') %}
+		          <li class="nav-item">
+			    <a class="nav-link" href="{{ url_for('apikeys.apikeys_index') }}">
+			      <i class="nav-icon icon-drop"></i> API Keys</a>
+		          </li>
+			{% endif %}
                       {% endif %}
 
                     </ul>
                   </li>
 
-                  {% if current_user.has_role('admin') %}
-                  <li class="nav-title">Administration</li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('main.user_admin_page') }}">
-                      <i class="nav-icon icon-drop"></i> Manage Users</a>
-                  </li>
+	          {% if current_user.is_authenticated %}
+			  {% if current_user.has_role('admin') %}
+			  <li class="nav-title">Administration</li>
+			  <li class="nav-item">
+			    <a class="nav-link" href="{{ url_for('main.user_admin_page') }}">
+			      <i class="nav-icon icon-drop"></i> Manage Users</a>
+			  </li>
+			  {% endif %}
                   {% endif %}
 
                 </ul>

--- a/app/views/apikeys.py
+++ b/app/views/apikeys.py
@@ -41,7 +41,7 @@ def apikeys_create():
 @apikeys_blueprint.route('/user/apikeys/<key_id>/delete', methods=['GET', 'POST'])
 @roles_accepted('dev', 'admin')
 def apikeys_delete(key_id):
-    form = forms.Confirm(request.form)
+    form = forms.ConfirmationForm(request.form)
     if request.method == 'POST':
         remove_key = users.ApiKey.query.filter_by(id=key_id, user_id=current_user.id).first()
         if remove_key:


### PR DESCRIPTION
I wasn't able to delete API keys, this PR fixes it:

 File "./app/views/apikeys.py", line 44, in apikeys_delete
     form = forms.Confirm(request.form)
     AttributeError: module 'app.utils.forms' has no attribute 'Confirm'